### PR TITLE
default.xml: Update kernel and u-boot revisions

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,8 +8,8 @@
 
   <!-- Modified/Added repositories -->
   <project path="device/xilinx" name="mpsoc-android_device_xilinx" remote="mentor-github" revision="zynqmp-android_7.1.2" />
-  <project path="linux-xlnx" name="mpsoc-linux-xlnx" remote="mentor-github" revision="zynqmp-android-4.9" />
-  <project path="bootable/u-boot-xlnx" name="mpsoc-u-boot-xlnx" remote="mentor-github" revision="zynqmp-android-xilinx-v2017.1" />
+  <project path="linux-xlnx" name="mpsoc-linux-xlnx" remote="mentor-github" revision="zynqmp-android-4.9-v2017.3" />
+  <project path="bootable/u-boot-xlnx" name="mpsoc-u-boot-xlnx" remote="mentor-github" revision="zynqmp-android-xilinx-v2017.3" />
   <project path="vendor/xilinx" name="mpsoc-android_vendor_xilinx" remote="mentor-github" revision="zynqmp-android_7.1.2" />
   <project path="frameworks/base" name="mpsoc-android_frameworks_base" groups="pdk-cw-fs,pdk-fs" remote="mentor-github" revision="zynqmp-android_7.1.2"/>
   <project path="external/wpa_supplicant_8" name="mpsoc-wpa_supplicant_8" remote="mentor-github" revision="zynqmp-android_6.0.1" />


### PR DESCRIPTION
Use Linux kernel and U-Boot from Xilinx v2017.3 release for Android 7
manifest.

Signed-off-by: Alexey Firago <alexey_firago@mentor.com>