### PR TITLE
default.xml: Add Xilinx VCU related repos

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -3,15 +3,23 @@
 
   <remote name="aosp" fetch="https://android.googlesource.com" review=""/>
   <remote name="mentor-github" fetch="git://github.com/MentorEmbedded/" review=""/>
+  <remote name="xilinx-github" fetch="git://github.com/Xilinx/" review=""/>
   <default remote="aosp" revision="refs/tags/android-7.1.2_r11" sync-j="4" />
   <remote  name="github" fetch="git://github.com/" />
 
   <!-- Modified/Added repositories -->
   <project path="device/xilinx" name="mpsoc-android_device_xilinx" remote="mentor-github" revision="zynqmp-android_7.1.2" />
-  <project path="linux-xlnx" name="mpsoc-linux-xlnx" remote="mentor-github" revision="zynqmp-android-4.9-v2017.3" />
+  <project path="linux-xlnx" name="mpsoc-linux-xlnx" remote="mentor-github" revision="zynqmp-android-4.9-2017.3_video_ea" />
   <project path="bootable/u-boot-xlnx" name="mpsoc-u-boot-xlnx" remote="mentor-github" revision="zynqmp-android-xilinx-v2017.3" />
   <project path="vendor/xilinx" name="mpsoc-android_vendor_xilinx" remote="mentor-github" revision="zynqmp-android_7.1.2" />
   <project path="frameworks/base" name="mpsoc-android_frameworks_base" groups="pdk-cw-fs,pdk-fs" remote="mentor-github" revision="zynqmp-android_7.1.2"/>
+
+  <!-- Xilinx VCU related repos -->
+  <project path="hardware/xilinx/vcu/vcu-firmware" name="vcu-firmware" remote="xilinx-github" revision="e4ea930101a307fb637399f1ada638ae9ff1822c" />
+  <project path="hardware/xilinx/vcu/vcu-modules" name="vcu-modules" remote="xilinx-github" revision="b78a787f538a5adcde874e08fee8b8c9af2a6186" />
+  <project path="hardware/xilinx/vcu/vcu-ctrl-sw" name="vcu-ctrl-sw" remote="mentor-github" revision="android-7_xilinx-v2017.4" />
+  <project path="hardware/xilinx/vcu/vcu-omx-il" name="vcu-omx-il" remote="mentor-github" revision="android-7_xilinx-v2017.4" />
+
   <project path="external/wpa_supplicant_8" name="mpsoc-wpa_supplicant_8" remote="mentor-github" revision="zynqmp-android_6.0.1" />
   <project path="hardware/ti/wlan" name="cyanogenmod/android_hardware_ti_wlan" remote="github" revision="stable/cm-13.0-ZNH5Y" />
 


### PR DESCRIPTION
Add Xilinx VCU related repositories:
* vcu-ctrl-sw - Allegro DVT control SW ported to Android
* vcu-omx-il - VCU OpenMaX Integration Layer
* vcu-modules - VCU kernel modules
* vcu-firmware - VCU Firmware binaries

Use kernel branch based on Xilinx 2017.3_video_ea branch.
This branch is based on Xilinx 2017.3 release and implements required
kernel drivers for Xilinx VCU TRD 2017.3. Once all VCU TRD related bits
will be merged to master branch of linux-xlnx, we'll switch back to it.

Signed-off-by: Alexey Firago <alexey_firago@mentor.com>