### PR TITLE
Updates for intermediate Android 8 with VCU release

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -17,7 +17,7 @@
   <project path="hardware/xilinx/vcu/vcu-firmware" name="vcu-firmware" remote="xilinx-github" revision="refs/tags/xilinx-v2018.1" />
   <project path="hardware/xilinx/vcu/vcu-modules" name="vcu-modules" remote="xilinx-github" revision="refs/tags/xilinx-v2018.1" />
   <project path="hardware/xilinx/vcu/vcu-ctrl-sw" name="vcu-ctrl-sw" remote="mentor-github" revision="android-8_xilinx-v2018.1" />
-  <project path="hardware/xilinx/vcu/vcu-omx-il" name="vcu-omx-il" remote="mentor-github" revision="android-8_xilinx-v2018.1" />
+  <project path="hardware/xilinx/vcu/vcu-omx-il" name="vcu-omx-il" remote="mentor-github" revision="android-8_xilinx-v2018.2" />
 
   <!-- Modified/Added repositories -->
   <project path="system/core" name="mpsoc-android_platform_system_core" remote="mentor-github" revision="zynqmp-android_8" groups="pdk" />

--- a/default.xml
+++ b/default.xml
@@ -24,6 +24,7 @@
   <project path="external/libdrm" name="mpsoc-android_external_libdrm" remote="mentor-github" revision="zynqmp-android_8" groups="pdk" />
   <project path="external/drm_hwcomposer" name="mpsoc-android_external_drm_hwcomposer" remote="mentor-github" revision="zynqmp-android_8" groups="drm_hwcomposer,pdk-fs" />
   <project path="packages/apps/Settings" name="mpsoc-android_packages_apps_settings" remote="mentor-github" revision="zynqmp-android_8" groups="pdk-fs" />
+  <project path="frameworks/av" name="mpsoc-android_frameworks_av" remote="mentor-github" revision="zynqmp-android_8" groups="pdk" />
 
   <!-- Unmodified AOSP repositories -->
   <project path="build/make" name="platform/build" groups="pdk" >
@@ -368,7 +369,6 @@
   <project path="external/zlib" name="platform/external/zlib" groups="pdk" />
   <project path="external/zopfli" name="platform/external/zopfli" groups="pdk" />
   <project path="external/zxing" name="platform/external/zxing" groups="pdk" />
-  <project path="frameworks/av" name="platform/frameworks/av" groups="pdk" />
   <project path="frameworks/base" name="platform/frameworks/base" groups="pdk-cw-fs,pdk-fs" />
   <project path="frameworks/compile/libbcc" name="platform/frameworks/compile/libbcc" groups="pdk" />
   <project path="frameworks/compile/mclinker" name="platform/frameworks/compile/mclinker" groups="pdk" />


### PR DESCRIPTION
Changes to support basic VCU decoder functionality:
* Use custom frameworks/av to force SW rendering of VCU decoder output
* Use vcu-omx-il 2018.2 with important bug fixes