### PR TITLE
default.xml: Update branch for drm_hwcomposer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -23,7 +23,7 @@
   <!-- Modified/Added repositories -->
   <project path="system/core" name="mpsoc-android_platform_system_core" remote="mentor-github" revision="zynqmp-android_8" groups="pdk" />
   <project path="external/libdrm" name="mpsoc-android_external_libdrm" remote="mentor-github" revision="zynqmp-android_8" groups="pdk" />
-  <project path="external/drm_hwcomposer" name="mpsoc-android_external_drm_hwcomposer" remote="mentor-github" revision="zynqmp-android_8" groups="drm_hwcomposer,pdk-fs" />
+  <project path="external/drm_hwcomposer" name="mpsoc-android_external_drm_hwcomposer" remote="mentor-github" revision="zynqmp-android_8-v2018.3" groups="drm_hwcomposer,pdk-fs" />
   <project path="packages/apps/Settings" name="mpsoc-android_packages_apps_settings" remote="mentor-github" revision="zynqmp-android_8" groups="pdk-fs" />
   <project path="frameworks/av" name="mpsoc-android_frameworks_av" remote="mentor-github" revision="zynqmp-android_8" groups="pdk" />
 


### PR DESCRIPTION
We have switched to upstream (freedesktop) drm_hwcomposer in
order to properly support overlay planes. It is unmergable with
current zynqmp-android_8, so use new branch.

Signed-off-by: Alexey Firago <alexey_firago@mentor.com>