### PR TITLE
default.xml: Update to xilinx 2019.2 release

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -9,16 +9,16 @@
 
   <!-- Xilinx MPSoC specific repositories -->
   <project path="device/xilinx" name="mpsoc-android_device_xilinx" remote="mentor-github" revision="zynqmp-android_8" />
-  <project path="linux-xlnx" name="mpsoc-linux-xlnx" remote="mentor-github" revision="zynqmp-android-4.14-v2018.3" />
+  <project path="linux-xlnx" name="mpsoc-linux-xlnx" remote="mentor-github" revision="zynqmp-android-4.19-v2019.2" />
   <project path="bootable/u-boot-xlnx" name="mpsoc-u-boot-xlnx" remote="mentor-github" revision="zynqmp-android-xilinx-v2017.3" />
   <project path="vendor/xilinx" name="mpsoc-android_vendor_xilinx" remote="mentor-github" revision="zynqmp-android_8" />
 
   <!-- Xilinx VCU related repos -->
-  <project path="hardware/xilinx/vcu/vcu-firmware" name="vcu-firmware" remote="xilinx-github" revision="refs/tags/xilinx-v2018.3" />
-  <project path="hardware/xilinx/vcu/vcu-modules" name="vcu-modules" remote="xilinx-github" revision="refs/tags/xilinx-v2018.3" />
-  <project path="hardware/xilinx/vcu/vcu-ctrl-sw" name="vcu-ctrl-sw" remote="mentor-github" revision="android-8_xilinx-v2018.3" />
-  <project path="hardware/xilinx/vcu/vcu-omx-il" name="vcu-omx-il" remote="mentor-github" revision="android-8_xilinx-v2018.3" />
-  <project path="hardware/xilinx/hdmi/hdmi-modules" name="mpsoc-hdmi-modules" remote="mentor-github" revision="android-8_xilinx-v2018.3" />
+  <project path="hardware/xilinx/vcu/vcu-firmware" name="vcu-firmware" remote="xilinx-github" revision="refs/tags/xilinx-v2019.2" />
+  <project path="hardware/xilinx/vcu/vcu-modules" name="vcu-modules" remote="xilinx-github" revision="refs/tags/xilinx-v2019.2" />
+  <project path="hardware/xilinx/vcu/vcu-ctrl-sw" name="vcu-ctrl-sw" remote="mentor-github" revision="android-8_xilinx-v2019.2" />
+  <project path="hardware/xilinx/vcu/vcu-omx-il" name="vcu-omx-il" remote="mentor-github" revision="android-8_xilinx-v2019.2" />
+  <project path="hardware/xilinx/hdmi/hdmi-modules" name="hdmi-modules" remote="xilinx-github" revision="rel-v2019.2" />
 
   <!-- Modified/Added repositories -->
   <project path="system/core" name="mpsoc-android_platform_system_core" remote="mentor-github" revision="zynqmp-android_8" groups="pdk" />


### PR DESCRIPTION
Use xilinx 2019.2 release as a base.

Signed-off-by: Alexey Firago <alexey_firago@mentor.com>